### PR TITLE
docs: fix _app.js props syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ import App from 'next/app'
 import { csrfToken } from '../lib/csrf';
 
 function MyApp({ Component, pageProps }) {
-  return <Component {...pageProps, csrfToken} />
+  return <Component {...pageProps} csrfToken={csrfToken} />
 }
 
 export default MyApp


### PR DESCRIPTION
Looks like the proposed syntax is incorrect