### PR TITLE
Bug fix extracting tokenFromHeaders

### DIFF
--- a/src/middleware/csrf.ts
+++ b/src/middleware/csrf.ts
@@ -43,15 +43,15 @@ const csrf = (
     }
 
     // 2. extract token from custom header
-    const tokenFromHeaders = parse(<string>getToken(req, tokenKey));
+    const tokenFromHeaders = <string>getToken(req, tokenKey);
 
     // We need the token in a custom header to verify Double-submit cookie pattern
-    if (!tokenFromHeaders.length) {
+    if (!tokenFromHeaders) {
       throw new HttpError(403, csrfErrorMessage);
     }
 
     const tokenFromHeadersUnsigned = unsign(
-      <string>tokenFromHeaders[tokenKey],
+      <string>tokenFromHeaders,
       secret
     );
 


### PR DESCRIPTION
no need to parse anything here, getToken returns the expected value and tokenFromHeaders is not a object