### PR TITLE
Avoid calling 'unsign' in case if the token from cookie is 'undefined…

### DIFF
--- a/src/middleware/csrf.test.ts
+++ b/src/middleware/csrf.test.ts
@@ -66,6 +66,23 @@ describe("csrf middleware", () => {
     expect(secondRequest.status).toBe(200);
   });
 
+  it("should validate a token with a secret and send 200 even if the cookie exists but is different from the XSRF token", async () => {
+    const server = http.createServer(requestListener);
+    const firstRequest = await request.agent(server).get("/");
+
+    // Grab the token and secret from the response
+    const [reqCsrfToken] = firstRequest.header["set-cookie"];
+
+    // Send back the token in a header and a cookie
+    const secondRequest = await request
+        .agent(server)
+        .get("/")
+        .set("Cookie", "anotherCookieThanXSRF")
+        .set(tokenKey, reqCsrfToken);
+
+    expect(secondRequest.status).toBe(200);
+  });
+
   it("should return 403 if we don't send a valid token in a custom header and a cookie", async () => {
     const server = http.createServer(requestListener);
     const firstRequest = await request.agent(server).post("/");

--- a/src/middleware/csrf.ts
+++ b/src/middleware/csrf.ts
@@ -23,7 +23,6 @@ const csrf = (
   try {
     // 1. extract secret and token from their cookies
     const tokenFromCookie = getCookie(req, tokenKey);
-    const tokenFromCookieUnsigned = unsign(tokenFromCookie, secret);
 
     // If no token in cookie then we assume first request and proceed to setup CSRF mitigation
     if (!tokenFromCookie) {
@@ -50,6 +49,7 @@ const csrf = (
       throw new HttpError(403, csrfErrorMessage);
     }
 
+    const tokenFromCookieUnsigned = unsign(tokenFromCookie, secret);
     const tokenFromHeadersUnsigned = unsign(
       <string>tokenFromHeaders,
       secret


### PR DESCRIPTION
Avoid calling 'unsign' in case if the token from cookie is 'undefined'. If the first argument is different from 'string', the unsign function will always throw "Signed cookie string must be provided."

`src/cookies/getCookie.ts`
```
function getCookie(req: NextApiRequest, name: string): string {
  if (req.headers.cookie != null) {
    const parsedCookie = parse(req.headers.cookie);
    return parsedCookie[name];
  }

  return "";
}
```

This function checks if `headers.cookie !== null` and is trying to get the token from parsed cookie, but the cookie could be present but different from XSRF token. 

Let's say I'm also using google analytics (gtag) that is making its own cookies such us: `_ga=GA1.1.1798070841.1638877244;`

parsedCookie will be:
```
parsedCookie = {
  "_ga"="GA1.1.1798070841.1638877244"
}
```

and the return statement `parsedCookie[name]` where name is `tokenKey` (by default `XSRF-TOKEN`) will be `undefined`

then...

`src/middleware/csrf.ts`
```
const tokenFromCookie = getCookie(req, tokenKey);
const tokenFromCookieUnsigned = unsign(tokenFromCookie, secret); 
```

since `tokenFromCookie` is undefined, and the first argument must be `typeof string`, this function will always throw "Signed cookie string must be provided." and the request will fail with status 500