### PR TITLE
handle getServerSideProps with return GetServerSideProps type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ const defaultOptions = {
   cookieOptions: cookieDefaultOptions,
 };
 
-type Middleware = (handler: NextApiHandler) => void;
+type Middleware = (handler: NextApiHandler) => any;
 
 type NextCSRF = {
   setup: Middleware;


### PR DESCRIPTION
when I use setup on  getServerSideProps: GetServerSideProps. It throw me an error like this :
Type 'void' is not assignable to type 'GetServerSideProps<{ [key: string]: any; }, ParsedUrlQuery, PreviewData>'