### PR TITLE
Do not lower case CSRF Secret key

### DIFF
--- a/src/utils/get-secret.ts
+++ b/src/utils/get-secret.ts
@@ -2,7 +2,7 @@ import { getCookie } from "./get-cookie";
 import { IncomingMessage } from "http";
 
 const getSecret = (req: IncomingMessage, tokenKey: string): string => {
-  return getCookie(req, tokenKey.toLowerCase());
+  return getCookie(req, tokenKey);
 };
 
 export { getSecret };


### PR DESCRIPTION
When retrieving the existing CSRF Secret as part of the `setup` function, do not call `toLowerCase` on the token key. Fixes #67